### PR TITLE
Koa v2 middleware signature, stylus update

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,16 @@
 'use strict';
 
-var stylus = require('stylus');
+const stylus = require('stylus');
 
 module.exports = function(options){
-  var middleware = stylus.middleware(options);
+  const middleware = stylus.middleware(options);
 
-  function compile(req, res){
-    return function(callback){
-      middleware(req, res, callback);
-    };
-  }
+  const compile = (req, res) => new Promise((resolve, reject) => {
+    middleware(req, res, err => err ? reject(err) : resolve());
+  });
 
-  return function*(next){
-    yield compile(this.req, this.res);
-    yield next;
+  return async function(ctx, next){
+    await compile(ctx.req, ctx.res);
+    await next();
   };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-stylus",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "Stylus middleware for Koa",
   "main": "index",
   "repository": {
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/yosssi/koa-stylus",
   "dependencies": {
-    "stylus": "0.54.2"
+    "stylus": "0.54.5"
   }
 }


### PR DESCRIPTION
Fix old middleware signature

> koa deprecated Support for generators will be removed in v3. See the documentation for examples of how to convert old middleware https://github.com/koajs/koa/blob/master/docs/migration.md

Update stylus version